### PR TITLE
fixes weekend count when starting by weekend day

### DIFF
--- a/github_metrics/helpers.py
+++ b/github_metrics/helpers.py
@@ -120,7 +120,10 @@ def get_weekend_time(start_at, end_at):
             # count from the beginning until end of day
             if i == 0:
                 weekends += (
-                    datetime.datetime(day.year, day.month, day.day, 23, 59, 59) - day
+                    datetime.datetime(day.year, day.month, day.day, 23, 59, 59).replace(
+                        tzinfo=day.tzinfo
+                    )
+                    - day
                 )
 
             # If it's the end of a time period, count from start of day until the end time


### PR DESCRIPTION
***Quick description:***

Fixes edge case of exclude_weekends flag:
- When a PR is created on the weekend, the line that sums one day more to the weekend variable would break because of timezone incompatibility. This PR adds timezone to fix this issue
