### PR TITLE
Handle PRs that were created as Draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Returns statistics related to the time between opening and merging a pull reques
 It measures the total number of merged pull requests to the total number of developers active in this time period (number of merged PRS / dev). A value closer to 1 indicates that each developer is merging a PR. a higher number indicates more merged PRs than devs, and vice versa.
 
 - <b id="pr-size">Pull Request Size (pr_size):</b>
-It generates metrics related to the number of lines added and deleted in a PR. The output will generate metrics related to the sum of different lines in a pr (lines added + lines deleted), and the addition rate metric (lines addes / lines deleted). In the latter case, a higher the rate number means more lines are being added than deleted.
+It generates metrics related to the number of lines added and deleted in a PR. The output will generate metrics related to the sum of different lines in a pr (lines added + lines deleted), and the addition rate metric (lines adds / lines deleted). In the latter case, a higher the rate number means more lines are being added than deleted.
 
 - <b id="hotfixes-count">Hotfixes Count (hotfixes_count):</b>
 The number of hotfixes in the period.
@@ -80,7 +80,7 @@ The number of hotfixes in the period.
 
 `Repository name`: The repository name of the project of your choice
 
-**NOTE:** Running the `--setup` flag will overwrite the existing enviroment settings.
+**NOTE:** Running the `--setup` flag will overwrite the existing environment settings.
 
 ## Project setup
 
@@ -109,7 +109,7 @@ Release Process
 For maintainers only:
 
 - Run `rm -rf build dist` to delete current build archives
-- Install dependencies with `pip install -r ./requirements.txt`. Make sure you are inside a virtual enviroment
+- Install dependencies with `pip install -r ./requirements.txt`. Make sure you are inside a virtual environment
 - Run ``bump2version <minor|major|patch>`` to update the version number (pick one of the options)
 
     - Version number on ``github_metrics/__init__.py`` and ``setup.py`` will be updated automatically

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Returns statistics related to the time between opening and merging a pull reques
 It measures the total number of merged pull requests to the total number of developers active in this time period (number of merged PRS / dev). A value closer to 1 indicates that each developer is merging a PR. a higher number indicates more merged PRs than devs, and vice versa.
 
 - <b id="pr-size">Pull Request Size (pr_size):</b>
-It generates metrics related to the number of lines added and deleted in a PR. The output will generate metrics related to the sum of different lines in a pr (lines added + lines deleted), and the addition rate metric (lines adds / lines deleted). In the latter case, a higher the rate number means more lines are being added than deleted.
+It generates metrics related to the number of lines added and deleted in a PR. The output will generate metrics related to the sum of different lines in a pr (lines added + lines deleted), and the addition rate metric (lines added / lines deleted). In the latter case, a higher the rate number means more lines are being added than deleted.
 
 - <b id="hotfixes-count">Hotfixes Count (hotfixes_count):</b>
 The number of hotfixes in the period.

--- a/github_metrics/common.py
+++ b/github_metrics/common.py
@@ -46,4 +46,4 @@ def _get_raw_ready_datetime_from_pr(pr):
     return timeline_node.get("createdAt", pr["createdAt"])
 
 def get_ready_datetime_from_pr(pr):
-    return arrow.get(_get_raw_ready_datetime_from_pr(pr)).datetime
+    return extract_datetime_or_none(_get_raw_ready_datetime_from_pr(pr))

--- a/github_metrics/common.py
+++ b/github_metrics/common.py
@@ -29,3 +29,21 @@ def get_reviews_from_pr(pr):
         return []
 
     return reviews
+
+def _get_raw_ready_datetime_from_pr(pr):
+    timeline_root = pr.get("timelineItems", {})
+    if not timeline_root:
+        return pr["createdAt"]
+
+    timeline = timeline_root.get("edges", [])
+    if not timeline or not timeline[0]:
+        return pr["createdAt"]
+
+    timeline_node = timeline[0].get("node")
+    if not timeline_node:
+        return pr["createdAt"]
+
+    return timeline_node.get("createdAt", pr["createdAt"])
+
+def get_ready_datetime_from_pr(pr):
+    return arrow.get(_get_raw_ready_datetime_from_pr(pr)).datetime

--- a/github_metrics/metrics/open_to_merge.py
+++ b/github_metrics/metrics/open_to_merge.py
@@ -1,6 +1,6 @@
 import numpy
 
-from github_metrics.common import extract_datetime_or_none, get_author_login
+from github_metrics.common import extract_datetime_or_none, get_author_login, get_ready_datetime_from_pr
 from github_metrics.helpers import (
     filter_valid_prs,
     format_timedelta_to_hours,
@@ -23,7 +23,7 @@ def format_pr_list(pr_list):
         {
             "title": pr["title"],
             "author": get_author_login(pr),
-            "created_at": extract_datetime_or_none(pr.get("createdAt")),
+            "ready_at": get_ready_datetime_from_pr(pr),
             "merged_at": extract_datetime_or_none(pr.get("mergedAt"))
             if pr.get("mergedAt")
             else None,
@@ -46,10 +46,10 @@ def get_open_to_merge_time_data(
     review_time_list = []
 
     for pr in merged_pr_list:
-        open_pr_duration = pr["merged_at"] - pr["created_at"]
+        open_pr_duration = pr["merged_at"] - pr["ready_at"]
         if exclude_weekends:
             open_pr_duration = get_time_without_weekend(
-                pr["created_at"], pr["merged_at"]
+                pr["ready_at"], pr["merged_at"]
             )
         review_time_list.append(open_pr_duration)
 

--- a/github_metrics/metrics/pr_size.py
+++ b/github_metrics/metrics/pr_size.py
@@ -56,12 +56,12 @@ def call_pr_size_statistics(pr_list, include_hotfixes, exclude_authors, filter_a
     print(
         f"     \033[1mPull Requests Size\033[0m\n"
         f"     ----------------------------------\n"
-        f"     Total PRs calculated: {len(data['formatted_pr_list'])}\n"
+        f"     Total PRs calculated: {len(data['total_prs'])}\n"
         f"     ----------------------------------\n"
         f"     Total Lines Mean: {round(data['total_mean'], 2)} lines\n"
         f"     Total Lines Median: {round(data['total_median'], 2)} lines\n"
-        f"     Total Lines 95 percentile: {round(data['total_percentile'], 2)} lines\n\n"
+        f"     Total Lines 95 percentile: {round(data['total_percentile_95'], 2)} lines\n\n"
         f"     Diff Rate Mean: {round(data['rate_mean'], 2)}\n"
         f"     Diff Rate Median: {round(data['rate_median'], 2)}\n"
-        f"     Diff Rate 95 percentile: {round(data['rate_percentile'], 2)}\n"
+        f"     Diff Rate 95 percentile: {round(data['rate_percentile_95'], 2)}\n"
     )

--- a/github_metrics/metrics/time_to_merge.py
+++ b/github_metrics/metrics/time_to_merge.py
@@ -1,6 +1,6 @@
 import numpy
 
-from github_metrics.common import extract_datetime_or_none, get_author_login
+from github_metrics.common import extract_datetime_or_none, get_author_login, get_ready_datetime_from_pr
 from github_metrics.helpers import (
     filter_valid_prs,
     format_timedelta_to_hours,
@@ -31,7 +31,7 @@ def format_pr_list(pr_list):
         {
             "title": pr["title"],
             "author": get_author_login(pr),
-            "created_at": extract_datetime_or_none(pr.get("createdAt")),
+            "ready_at": get_ready_datetime_from_pr(pr),
             "merged_at": extract_datetime_or_none(pr.get("mergedAt"))
             if pr.get("mergedAt")
             else None,

--- a/github_metrics/metrics/time_to_open.py
+++ b/github_metrics/metrics/time_to_open.py
@@ -1,6 +1,6 @@
 import numpy
 
-from github_metrics.common import extract_datetime_or_none, get_author_login
+from github_metrics.common import extract_datetime_or_none, get_author_login, get_ready_datetime_from_pr
 from github_metrics.helpers import (
     filter_valid_prs,
     format_timedelta_to_hours,
@@ -31,7 +31,7 @@ def format_pr_list(pr_list):
         {
             "title": pr["title"],
             "author": get_author_login(pr),
-            "created_at": extract_datetime_or_none(pr.get("createdAt")),
+            "ready_at": get_ready_datetime_from_pr(pr),
             "merged_at": extract_datetime_or_none(pr.get("mergedAt"))
             if pr.get("mergedAt")
             else None,
@@ -58,9 +58,9 @@ def get_time_to_open_data(
     time_to_open = []
     for pr in formatted_pr_list:
         first_commit_time = pr["commits"][0]["commited_at"]
-        timedelta = pr["created_at"] - first_commit_time
+        timedelta = pr["ready_at"] - first_commit_time
         if exclude_weekends:
-            timedelta = get_time_without_weekend(first_commit_time, pr["created_at"])
+            timedelta = get_time_without_weekend(first_commit_time, pr["ready_at"])
         time_to_open.append(timedelta)
 
     mean = numpy.mean(time_to_open)

--- a/github_metrics/metrics/time_to_review.py
+++ b/github_metrics/metrics/time_to_review.py
@@ -1,7 +1,7 @@
 import arrow
 import numpy
 
-from github_metrics.common import extract_datetime_or_none, get_author_login
+from github_metrics.common import extract_datetime_or_none, get_author_login, get_ready_datetime_from_pr
 from github_metrics.helpers import (
     filter_valid_prs,
     format_timedelta_to_hours,
@@ -38,7 +38,7 @@ def get_first_review(pr):
 
 
 def hours_without_review(pr):
-    open_date = extract_datetime_or_none(pr["created_at"])
+    open_date = extract_datetime_or_none(pr["ready_at"])
 
     if pr["first_review_at"] is None:
         time_without_review = arrow.now() - open_date
@@ -57,7 +57,7 @@ def format_pr_list(pr_list):
         {
             "title": pr["title"],
             "author": get_author_login(pr),
-            "created_at": extract_datetime_or_none(pr.get("createdAt")),
+            "ready_at": get_ready_datetime_from_pr(pr),
             "first_review_at": extract_datetime_or_none(
                 get_first_review(pr).get("createdAt")
             )
@@ -88,10 +88,10 @@ def get_time_to_review_data(
 
     review_time_list = []
     for pr in reviewed_prs:
-        review_time = pr["first_review_at"] - pr["created_at"]
+        review_time = pr["first_review_at"] - pr["ready_at"]
         if exclude_weekends:
             review_time = get_time_without_weekend(
-                pr["created_at"], pr["first_review_at"]
+                pr["ready_at"], pr["first_review_at"]
             )
         review_time_list.append(review_time)
 

--- a/github_metrics/request.py
+++ b/github_metrics/request.py
@@ -69,6 +69,16 @@ def format_request_for_github(cursor=None):
                             }}
                         }}
                     }}
+                    timelineItems(last: 1, itemTypes: READY_FOR_REVIEW_EVENT) {{
+                        edges {{
+                            node {{
+                                ... on ReadyForReviewEvent {{
+                                    id
+                                    createdAt
+                                }}
+                            }}
+                        }}
+                    }}
                 }}
             }}
         }}

--- a/tests/test_time_to_review.py
+++ b/tests/test_time_to_review.py
@@ -19,15 +19,15 @@ class TestPRsMTR(unittest.TestCase):
     def test_filter_prs_with_more_than_18h_before_review(self):
         pr_list = [
             {
-                "created_at": datetime.datetime(2021, 3, 25, 14, 28, 52),
+                "ready_at": datetime.datetime(2021, 3, 25, 14, 28, 52),
                 "first_review_at": None,
             },
             {
-                "created_at": datetime.datetime(2021, 3, 2, 10, 10),
+                "ready_at": datetime.datetime(2021, 3, 2, 10, 10),
                 "first_review_at": datetime.datetime(2021, 3, 4, 15, 12),
             },
             {
-                "created_at": datetime.datetime(2021, 3, 2, 10, 10),
+                "ready_at": datetime.datetime(2021, 3, 2, 10, 10),
                 "first_review_at": datetime.datetime(2021, 3, 2, 11, 3),
             },
         ]


### PR DESCRIPTION
It's possible to obtain the date a PR was tagged as "Ready" from graphql by searching for the last timelineItem of READY_FOR_REVIEW type:
```graphql
timelineItems(last: 1, itemTypes: READY_FOR_REVIEW_EVENT) {{
  edges {{
    node {{
      ... on ReadyForReviewEvent {{
        id
        createdAt
      }}
   }}
  }}
}}
```

That enables us to update our metrics to account for PRs created on draft

--------------

Example test run on plusplusco/plusplus:
`github_metrics --metric=ttr --start-date=2023-01-01 --end-date=2023-02-07 --exclude-weekends`


Before changes:
```
Time to review
    ----------------------------------
    Total valid PRs: 157
    Unreviewed PRs: 7 (4.46%)
    PRs with more than 24h waiting for review: 21 (13.38%)
    ----------------------------------
    Mean: 0 days 6 hours 30 minutes (6.52 hours)
    Median: 0 days 0 hours 28 minutes (0.48 hours)
    95 percentile: 1 days 0 hours 17 minutes (24.3 hours)
```

After changes:
```
Time to review
    ----------------------------------
    Total valid PRs: 157
    Unreviewed PRs: 7 (4.46%)
    PRs with more than 24h waiting for review: 16 (10.19%)
    ----------------------------------
    Mean: 0 days 4 hours 46 minutes (4.77 hours)
    Median: 0 days 0 hours 28 minutes (0.47 hours)
    95 percentile: 0 days 21 hours 4 minutes (21.07 hours)
```